### PR TITLE
Fix points in description of cart_pole_pixels

### DIFF
--- a/tasks/cart_pole_pixels.md
+++ b/tasks/cart_pole_pixels.md
@@ -9,9 +9,9 @@ as an $80×80$ `np.uint8` image with three channels, with each channel represent
 
 During evaluation in ReCodEx, three different random seeds will be employed,
 each with time limit of 10 minutes, and if you reach an average return at least
-450 on all of them, you obtain 4 points. The task is also
+450 on all of them, you obtain 3 points. The task is also
 a [_competition_](https://ufal.mff.cuni.cz/courses/npfl139/2324-summer#competitions),
-and at most 5 points will be awarded according to relative ordering of your
+and at most 4 points will be awarded according to relative ordering of your
 solutions.
 
 The [cart_pole_pixels.py](https://github.com/ufal/npfl139/tree/master/labs/06/cart_pole_pixels.py)


### PR DESCRIPTION
There is a mismatch between the points mentioned in the assignment header and the description. 