### PR TITLE
Fix/lab 8 typos

### DIFF
--- a/labs/08/paac.py
+++ b/labs/08/paac.py
@@ -47,7 +47,7 @@ class Network:
         #
         # The `args.entropy_regularization` might be used to include actor
         # entropy regularization -- the assignment can be solved even without
-        # it, but my reference solutions learns more quickly when using it.
+        # it, but my reference solution learns more quickly when using it.
         # In any case, `torch.distributions.Categorical` is the suitable distribution
         # offering the `.entropy()` method.
         raise NotImplementedError()

--- a/labs/08/paac_continuous.py
+++ b/labs/08/paac_continuous.py
@@ -33,7 +33,7 @@ class Network:
         # - actor, which predicts distribution over the actions
         # - critic, which predicts the value function
         #
-        # The given states are tile encoded, so they are integral indices of
+        # The given states are tile encoded, so they are integer indices of
         # tiles intersecting the state. Therefore, you should convert them
         # to dense encoding (one-hot-like, with `args.tiles` ones).
         # (Or you could even use `torch.nn.EmbeddingBag`, but be careful

--- a/tasks/ddpg.md
+++ b/tasks/ddpg.md
@@ -1,5 +1,5 @@
 ### Assignment: ddpg
-#### Date: Deadline: Apr 23, 22:0
+#### Date: Deadline: Apr 23, 22:00
 #### Points: 5 points
 
 Solve the continuous [Pendulum-v1](https://gymnasium.farama.org/environments/classic_control/pendulum/)

--- a/tasks/paac.md
+++ b/tasks/paac.md
@@ -1,5 +1,5 @@
 ### Assignment: paac
-#### Date: Deadline: Apr 23, 22:0
+#### Date: Deadline: Apr 23, 22:00
 #### Points: 3 points
 
 Solve the [CartPole-v1 environment](https://gymnasium.farama.org/environments/classic_control/cart_pole/)

--- a/tasks/paac_continuous.md
+++ b/tasks/paac_continuous.md
@@ -1,5 +1,5 @@
 ### Assignment: paac_continuous
-#### Date: Deadline: Apr 23, 22:0
+#### Date: Deadline: Apr 23, 22:00
 #### Points: 4 points
 
 Solve the [MountainCarContinuous-v0 environment](https://gymnasium.farama.org/environments/classic_control/mountain_car_continuous/)


### PR DESCRIPTION
Fixes typo in `paac.py`, adds missing "0" to "22:00" for task markdown files.

Also changes "integral indices" to "integer indices" in `paac_continuous.py`. I am not so sure about this change, but "integral" evokes calculus instead of the adjective form of "integer" for me.

Please, select to use or omit any of the changes.
