### PR TITLE
Allow passing reset arguments via options.

### DIFF
--- a/labs/npfl139/evaluation_env.py
+++ b/labs/npfl139/evaluation_env.py
@@ -38,6 +38,11 @@ class EvaluationEnv(gym.Wrapper):
         return len(self._episode_returns)
 
     def reset(self, *, start_evaluation=False, logging=True, seed=None, options=None):
+        if options is not None and "start_evaluation" in options.keys():
+            start_evaluation = options["start_evaluation"]
+        if options is not None and "logging" in options.keys():
+            logging = options["logging"]
+
         if seed is not None:
             raise RuntimeError("The EvaluationEnv cannot be reseeded")
         if self._evaluating_from is not None and self._episode_running:

--- a/labs/npfl139/evaluation_env.py
+++ b/labs/npfl139/evaluation_env.py
@@ -39,9 +39,9 @@ class EvaluationEnv(gym.Wrapper):
 
     def reset(self, *, start_evaluation=False, logging=True, seed=None, options=None):
         if options is not None and "start_evaluation" in options.keys():
-            start_evaluation = options["start_evaluation"]
+            start_evaluation = options["start_evaluation"] or start_evaluation
         if options is not None and "logging" in options.keys():
-            logging = options["logging"]
+            logging = options["logging"] and logging
 
         if seed is not None:
             raise RuntimeError("The EvaluationEnv cannot be reseeded")


### PR DESCRIPTION
I have a proposal for a slight change which would make it easier to use wrappers around `EvaluationEnv`.

Right now, the `start_evaluation` and `logging` options to `reset` are passed as separate arguments, while Gymnasium already has a system for passing extra information to the `reset` method --- the `options` argument.

This system is not viable when I want to use another wrapper around the `EvaluationEnv`, for example to modify the observation or action spaces --- the wrapper only passes the `seed` and `options` to the wrapped env, not the extra arguments.

My proposal is to additionally allow to pass the extra args inside the `options`, while keeping the current API present.
Note that in my implementation, the values from `options`, if present, overwrite the values passed as arguments.

Now, something like 
```python
env = npfl139.EvaluationEnv(...)
env = gym.wrappers.TransformReward(env, lambda r: -1 if r < 0 else 1)
env.reset(options={"start_evaluation": True})
```
would be possible.