### PR TITLE
fix typo in quantile regression leibniz

### DIFF
--- a/slides/05/05.md
+++ b/slides/05/05.md
@@ -547,7 +547,7 @@ $F_P$.
   $\displaystyle \hphantom{\frac{∂}{∂x̂} ∫_{-∞}^{∞} P(x) |x̂ - x| \d x} = ∫_{-∞}^{x̂} P(x) \d x - ∫_x̂^∞ P(x) \d x$
 
 ~~~
-  $\displaystyle \hphantom{\frac{∂}{∂x̂} ∫_{-∞}^{∞} P(x) |x̂ - x| \d x} = 2 ∫_{-∞}^{x̂} P(x) \d x - 1 = 2 F_P(x̂) - 1 = \tfrac{1}{2} \big(F_P(x̂) - \tfrac{1}{2}\big).$
+  $\displaystyle \hphantom{\frac{∂}{∂x̂} ∫_{-∞}^{∞} P(x) |x̂ - x| \d x} = 2 ∫_{-∞}^{x̂} P(x) \d x - 1 = 2 F_P(x̂) - 1 = 2 \big(F_P(x̂) - \tfrac{1}{2}\big).$
 
 ---
 class: dbend


### PR DESCRIPTION
Hi,

there is a small typo on slide 47 in lecture 5. Towards the end of the derivation using Leibniz the whole thing should probably be _multiplied by 2_ instead of current _division by 2_.

This PR fixes that. 