### PR TITLE
aligned doc with gymnasium

### DIFF
--- a/labs/npfl139/envs/car_racing.py
+++ b/labs/npfl139/envs/car_racing.py
@@ -541,8 +541,8 @@ class CarRacingFS(gym.Env, EzPickle):
     * `domain_randomize=False` enables the domain randomized variant of the environment.
      In this scenario, the background and track colours are different on every reset.
 
-    * `continuous=True` converts the environment to use discrete action space.
-     The discrete action space has 5 actions: [do nothing, left, right, gas, brake].
+    * `continuous=True` specifies if the agent has continuous (true) or discrete (false) actions.
+     See action space section for a description of each.
 
     ## Reset Arguments
 


### PR DESCRIPTION
Changed CarRacingFS docstring of the `continuous` argument to match the CarRacing from gymnasium Farama-Foundation/Gymnasium@6e8227a30bed9e4d5c17bb19437bc2959c031fcc.